### PR TITLE
弾丸が発射されない不具合を修正した

### DIFF
--- a/shooting/Bullet.pde
+++ b/shooting/Bullet.pde
@@ -1,25 +1,23 @@
 class Bullet {
   int ap;
-  int x,y;
+  int x, y;
   float speed;
   
-  Bullet(int ap,int x, int y, float speed){
+  Bullet(int ap, int x, int y, float speed){
     this.ap = ap;
     this.x = x;
     this.y = y;
     this.speed = speed;
   }
-  public int getX(){//弾の座標を習得
+  public int getX(){ // 弾の座標を習得
     return this.x;
   }
-  public int getY(){//弾の座標を習得
+  public int getY(){ // 弾の座標を習得
     return this.y;
   }
   
   void update(){
-    y-=speed;
-    ellipse(x,y,10,10);
+    y -= speed;
+    ellipse(x, y, 10, 10);
   }
 }
-  
-  

--- a/shooting/Enemy.pde
+++ b/shooting/Enemy.pde
@@ -21,7 +21,6 @@ class Enemy {
         bulletList.remove(i);
         if (this.hp <= 0) return true;
       }
-      bulletList.remove(i);
       if (this.hp <= 0) {
         //this.remove();
         return true;

--- a/shooting/Enemy.pde
+++ b/shooting/Enemy.pde
@@ -31,6 +31,6 @@ class Enemy {
   }
 
   void update() {
-    triangle( x, y-7, x -10, y+7, x+10, y+7);
+    triangle(x, y-7, x-10, y+7, x+10, y+7);
   }
 }

--- a/shooting/Enemy.pde
+++ b/shooting/Enemy.pde
@@ -24,8 +24,8 @@ class Enemy {
       bulletList.remove(i);
       if (this.hp <= 0) {
         //this.remove();
-        return  true;
-      } 
+        return true;
+      }
     }
     return false;
   }

--- a/shooting/Enemy.pde
+++ b/shooting/Enemy.pde
@@ -11,17 +11,15 @@ class Enemy {
   }
 
   boolean hit(ArrayList<Bullet> bulletList) {
-    for (int i = bulletList.size() -1; i>=0; i--) {
-      //bulletList.get(i);
+    for (int i = bulletList.size() - 1; i >= 0; i--) {
+      // bulletList.get(i);
       // bulletList.get(i).update(); 
       // bulletList.get(i).getX();
       // bulletList.get(i).getY();
       if (abs(bulletList.get(i).getX() - this.x) <= 30 && abs(bulletList.get(i).getY() - this.y) <= 30) {
         this.hp -= 10;
         bulletList.remove(i);
-        if (this.hp <= 0) {
-          return true;
-        }
+        if (this.hp <= 0) return true;
       }
       bulletList.remove(i);
       if (this.hp <= 0) {
@@ -32,9 +30,7 @@ class Enemy {
     return false;
   }
 
-
   void update() {
-
     triangle( x, y-7, x -10, y+7, x+10, y+7);
   }
 }

--- a/shooting/Player.pde
+++ b/shooting/Player.pde
@@ -12,18 +12,18 @@ class Player {
   }
 
   public void move() {
-    if ((keyStat&0x1)!=0) y -= speed;
-    if ((keyStat&0x2)!=0) y += speed;
-    if ((keyStat&0x4)!=0) x -= speed;
-    if ((keyStat&0x8)!=0) x += speed;
+    if ((keyStat&0x1) != 0) y -= speed;
+    if ((keyStat&0x2) != 0) y += speed;
+    if ((keyStat&0x4) != 0) x -= speed;
+    if ((keyStat&0x8) != 0) x += speed;
   }
   
   public void shoot(ArrayList<Bullet> bulletList) {
-    bulletList.add(new Bullet(10,x,y,10f));
+    bulletList.add(new Bullet(10, x, y, 10f));
   }
 
   public void update() {
     move();
-    triangle( x, y-7, x -10, y+7, x+10, y+7);
+    triangle(x, y-7, x-10, y+7, x+10, y+7);
   }
 }

--- a/shooting/Player.pde
+++ b/shooting/Player.pde
@@ -1,11 +1,9 @@
-
 //自機クラス
-class Player {//Classは設計図
+class Player {
   int hp;
   int x, y;
   float speed;
-  
-  //コンストラクタ
+
   public Player(int hp, int x, int y, float speed) {
     this.hp = hp;
     this.x = x;
@@ -13,31 +11,19 @@ class Player {//Classは設計図
     this.speed = speed;
   }
 
-
   public void move() {
-
-    if ((keyStat&0x1)!=0 ) {
-      y -= speed;
-    }
-    if ((keyStat&0x2)!=0) {
-      y += speed;
-    }
-    if ((keyStat&0x4)!=0) {
-      x -= speed;
-    }
-
-    if ((keyStat&0x8)!=0) {
-      x += speed;
-    }
+    if ((keyStat&0x1)!=0) y -= speed;
+    if ((keyStat&0x2)!=0) y += speed;
+    if ((keyStat&0x4)!=0) x -= speed;
+    if ((keyStat&0x8)!=0) x += speed;
   }
   
-  public void shoot(ArrayList<Bullet> bulletList){
+  public void shoot(ArrayList<Bullet> bulletList) {
     bulletList.add(new Bullet(10,x,y,10f));
-    
   }
+
   public void update() {
     move();
-
     triangle( x, y-7, x -10, y+7, x+10, y+7);
   }
 }

--- a/shooting/shooting.pde
+++ b/shooting/shooting.pde
@@ -35,8 +35,8 @@ void draw() {
   
   // enemy.hit(bulletList);
   for (int i = 0; i < enemyList.size(); i++) { // enemyを生成する
-    enemyList.get(i).update();
     if ( enemyList.get(i).hit(bulletList) ) enemyList.remove(i);
+    else enemyList.get(i).update();
   }
   for (int i = bulletList.size() - 1; i >= 0; i--) {
     // bulletList.get(i);

--- a/shooting/shooting.pde
+++ b/shooting/shooting.pde
@@ -19,6 +19,7 @@ void setup() {
     enemyList.add(new Enemy(100, (int)random(400), (int)random(200), 2.5f)); // ランダム関数の導入
   }
 }
+
 // 毎フレーム呼ばれるもの
 void draw() {
   background(255, 255, 0);
@@ -44,45 +45,44 @@ void draw() {
 }
 
 void keyPressed() {
-  if (key_flag) {
-    if (key == CODED) {
-      switch(keyCode) {
-        // ビットセット
-      case UP:
-        keyStat|=0x1;
-        break;
-      case DOWN:
-        keyStat|=0x2;
-        break;
-      case LEFT:
-        keyStat|=0x4;
-        break;
-      case RIGHT:
-        keyStat|=0x8;
-        break;
-      case SHIFT:
-        keyStat|=0x10;
-        break;
-      }
-    }
-    switch(key) {
-    case 'z':
-    case 'Z':
-      keyStat|=0x20;
+  if (!key_flag) return;
+  if (key == CODED) {
+    switch(keyCode) {
+    // ビットセット
+    case UP:
+      keyStat|=0x1;
       break;
-    case 'x':
-    case 'X':
-      keyStat|=0x40;
+    case DOWN:
+      keyStat|=0x2;
       break;
-    case's':
-    case'S':
-      keyStat|=0x80;
+    case LEFT:
+      keyStat|=0x4;
       break;
-    case 'a':
-    case 'A':
-      keyStat|=0x100;
+    case RIGHT:
+      keyStat|=0x8;
+      break;
+    case SHIFT:
+      keyStat|=0x10;
       break;
     }
+  }
+  switch(key) {
+  case 'z':
+  case 'Z':
+    keyStat|=0x20;
+    break;
+  case 'x':
+  case 'X':
+    keyStat|=0x40;
+    break;
+  case's':
+  case'S':
+    keyStat|=0x80;
+    break;
+  case 'a':
+  case 'A':
+    keyStat|=0x100;
+    break;
   }
 }
 

--- a/shooting/shooting.pde
+++ b/shooting/shooting.pde
@@ -1,44 +1,44 @@
-int keyStat; //キーの状態を格納する変数
+int keyStat; // キーの状態を格納する変数
 boolean key_flag = true;
-private ArrayList<Bullet> bulletList;//プライベート変数
+private ArrayList<Bullet> bulletList; // プライベート変数
 private ArrayList<Enemy> enemyList;
 
 Player player;
-//Enemy enemy;
+// Enemy enemy;
 
-//一番最初に一回だけ呼ばれる
+// 一番最初に一回だけ呼ばれる
 void setup() {
   size(960, 720);
   frameRate(60);
   rectMode(CENTER); // center mode
-  player = new Player(100, 200, 300, 2.5f);//インスタンス化:オブジェクトを生成する（実体化する）(今回はnew Player...）
-  //enemy =new Enemy(0,400,200,2.5f);
+  player = new Player(100, 200, 300, 2.5f); // インスタンス化:オブジェクトを生成する（実体化する）(今回はnew Player...）
+  // enemy = new Enemy(0, 400, 200, 2.5f);
   enemyList = new ArrayList<Enemy>();
   bulletList = new ArrayList<Bullet>();
-  for (int i = 0; i<=10; i++) {
-    enemyList.add(new Enemy(100, (int)random(400), (int)random(200), 2.5f));//ランダム関数の導入
+  for (int i = 0; i <= 10; i++) {
+    enemyList.add(new Enemy(100, (int)random(400), (int)random(200), 2.5f)); // ランダム関数の導入
   }
 }
-//毎フレーム呼ばれるもの
+// 毎フレーム呼ばれるもの
 void draw() {
   background(255, 255, 0);
   player.update();
   // enemy.update();
   fill(0, 0, 255);
-  text(frameCount, 900, 100);//フレームカウント
-  if ((keyStat&0x20)!=0) {
+  text(frameCount, 900, 100); // フレームカウント
+  if ((keyStat&0x20) != 0) {
     if (frameCount % 10 == 0) {
       player.shoot(bulletList);
     }
   }
   
-  //enemy.hit(bulletList);
-  for (int i=0; i<enemyList.size(); i++) {//enemyを生成する
+  // enemy.hit(bulletList);
+  for (int i = 0; i < enemyList.size(); i++) { // enemyを生成する
     enemyList.get(i).update();
-    if( enemyList.get(i).hit(bulletList) ) enemyList.remove(i);
+    if ( enemyList.get(i).hit(bulletList) ) enemyList.remove(i);
   }
-  for (int i = bulletList.size() -1; i>=0; i--) {
-    //bulletList.get(i);
+  for (int i = bulletList.size() - 1; i >= 0; i--) {
+    // bulletList.get(i);
     bulletList.get(i).update();
   }
 }
@@ -47,7 +47,7 @@ void keyPressed() {
   if (key_flag) {
     if (key == CODED) {
       switch(keyCode) {
-        //ビットセット
+        // ビットセット
       case UP:
         keyStat|=0x1;
         break;
@@ -89,7 +89,7 @@ void keyPressed() {
 void keyReleased() {
   if (key == CODED) {
     switch(keyCode) {
-      //ビットクリア
+      // ビットクリア
     case UP:
       keyStat&=~0x1;
       break;


### PR DESCRIPTION
原因は、コンフリクトを修正しているときに Enemy.pde に紛れ込んだ  ``bulletList.remove(i);`` というステートメントでした。
これは Enemy クラスの hit メソッドが呼び出されると必ず呼び出され、いくらZキーを押して弾丸を生成しても ( ``bulletList`` に ``new Bullet(...)`` を追加しても ) 即座に削除され、弾丸が消えてしまう、といったバグでした。
よって、この紛れ込んだ ``bulletList.remove(i);`` を削除すると、バグが治りました。